### PR TITLE
feat(scripts): seeding from LLC tests

### DIFF
--- a/scripts/classify_llc_tests.py
+++ b/scripts/classify_llc_tests.py
@@ -1,9 +1,10 @@
 from itertools import groupby
 from pathlib import Path
-import re
-from typing import Callable, Iterable, List, Optional
+from typing import List, Optional
 import pandas as pd
 from tap import Tap
+
+from llc_test_parsing import LLCTest, parse_llc_tests
 
 
 class Args(Tap):
@@ -20,162 +21,6 @@ class Args(Tap):
         self.add_argument("-i", "--input")
 
 
-class LLCCommand:
-    arch: str
-    cpu: Optional[str]
-    triple: Optional[str]
-    attrs: List[str]
-    global_isel: bool
-
-    def __init__(self, command: str, default_triple: Optional[str] = None) -> None:
-        assert "llc" in command
-
-        if (match := re.match(r".*-mtriple[= ]\"?([a-z0-9-]+)", command)) is not None:
-            self.triple = match.group(1)
-        else:
-            self.triple = default_triple
-
-        if (match := re.match(r".*-march[= ]\"?([a-z0-9-]+)", command)) is not None:
-            self.arch = match.group(1)
-        elif self.triple is not None:
-            self.arch = self.triple.split("-")[0]
-        else:
-            raise Exception(f"Failed to determine arch")
-
-        assert self.triple is not None or self.arch is not None, f"FATAL"
-
-        if (match := re.match(r".*-mcpu[= ]\"?([a-z0-9-]+)", command)) is not None:
-            self.cpu = match.group(1)
-        else:
-            self.cpu = None
-
-        self.attrs = re.findall(r"-mattr[= ]\"?([a-z0-9-]+)", command)
-        self.global_isel = re.match(r".*-global-isel", command) is not None
-
-
-class LLCTest:
-    path: Path
-
-    arch: str
-
-    test_commands: List[str]
-
-    runnable_llc_commands: List[LLCCommand]
-    """
-    llc commands that can be directly executed without crashing using the test case as an input
-    without going through `opt`, `sed`, etc. first.
-    """
-
-    code_lines: List[str]
-
-    def __init__(self, arch: str, file_path: Path) -> None:
-        assert file_path.name.endswith(".ll")
-
-        self.arch = arch
-        self.path = file_path
-        self.test_commands = []
-        self.code_lines = []
-
-        with open(file_path) as file:
-            multiline_command = False  # whether last RUN header ends with '\'
-            while line := file.readline():
-                if re.match(r".*;.+NOTE:(.+)", line):
-                    continue
-
-                match = re.match(r".*;.*RUN:(.+)", line)
-
-                if match is not None:
-                    command = match.group(1).strip()
-
-                    if multiline_command:
-                        last_command_prev_part = (
-                            self.test_commands[-1].removesuffix("\\").strip()
-                        )
-                        self.test_commands[-1] = f"{last_command_prev_part} {command}"
-                    else:
-                        self.test_commands.append(command)
-
-                    multiline_command = command.endswith("\\")
-                else:
-                    assert (
-                        not multiline_command
-                    ), f"ERROR: something unexpected happened when parsing commands for {file_path}"
-                    self.code_lines.append(line)
-
-        assert (
-            len(self.test_commands) > 0
-        ), f"WARNING: {file_path} does not contain any test command."
-
-        assert (
-            len(self.code_lines) > 0
-        ), f"WARNING: {file_path} does not contain any test code."
-
-        llc_commands = [cmd for cmd in self.test_commands if "llc " in cmd]
-        assert (
-            len(llc_commands) > 0
-        ), f"WARNING: {file_path} does not contain any `llc` command."
-
-        default_triple = self.get_default_triple()
-        runnable_llc_commands_raw = filter(
-            lambda cmd: cmd.startswith("llc"),
-            (cmd.split("|")[0] for cmd in llc_commands),
-        )
-
-        try:
-            self.runnable_llc_commands = [
-                LLCCommand(cmd, default_triple) for cmd in runnable_llc_commands_raw
-            ]
-        except Exception as e:
-            raise Exception(
-                f"ERROR: Failed to parse llc command(s) in {file_path}."
-            ) from e
-
-        assert (
-            len(self.runnable_llc_commands) > 0
-        ), f"WARNING: {file_path} does not contain any runnable `llc` command."
-
-    def get_default_triple(self) -> Optional[str]:
-        lines_with_triple = [
-            line for line in self.code_lines if line.startswith("target triple")
-        ]
-
-        if len(lines_with_triple) == 0:
-            return None
-
-        assert (
-            len(lines_with_triple) == 1
-        ), f"UNEXPECTED: {self.path} has more than one triple specified in code"
-
-        match = re.match(r'target triple ?= ?"([a-z0-9_\.-]+)"', lines_with_triple[0])
-        assert (
-            match is not None
-        ), f"UNEXPECTED: failed to extract triple from '{lines_with_triple[0]}'"
-
-        return match.group(1)
-
-
-def parse_all_llc_tests(
-    llvm_root: Path, arch_filter: Callable[[str], bool] = lambda _: True
-) -> Iterable[LLCTest]:
-    total = 0
-    success = 0
-
-    for arch_dir in llvm_root.joinpath("llvm/test/CodeGen").iterdir():
-        if not arch_dir.is_dir() or not arch_filter(arch_dir.name):
-            continue
-
-        for file_path in arch_dir.rglob("*.ll"):
-            try:
-                yield LLCTest(arch_dir.name, file_path)
-                success += 1
-            except Exception as e:
-                print(e)
-            total += 1
-
-    print(f"Successfully parsed {success}/{total} LLC tests.")
-
-
-
 def classify(
     arch: str,
     tests: List[LLCTest],
@@ -188,11 +33,11 @@ def classify(
         columns=["arch", "gisel", "triple", "cpu", "attrs"],
         data=(
             [
-                cmd.arch,
+                cmd.arch_with_sub,
                 cmd.global_isel,
                 cmd.triple,
                 cmd.cpu,
-                " ".join(sorted(cmd.attrs)),
+                ",".join(sorted(cmd.attrs)),
             ]
             for cmd in commands
         ),
@@ -225,11 +70,22 @@ def classify(
 
             for test in tests:
                 try:
-                    if any(cmd.arch == subarch for cmd in test.runnable_llc_commands):
-                        if any(not cmd.global_isel for cmd in test.runnable_llc_commands):
-                            dagisel_seeds_dir.joinpath(test.path.name).symlink_to(test.path.absolute())
+                    if any(
+                        cmd.arch_with_sub == subarch
+                        for cmd in test.runnable_llc_commands
+                    ):
+                        if any(
+                            not cmd.global_isel for cmd in test.runnable_llc_commands
+                        ):
+                            dagisel_seeds_dir.joinpath(test.path.name).symlink_to(
+                                test.path.absolute()
+                            )
+                            test.dump_bc(dagisel_seeds_dir)
                         if any(cmd.global_isel for cmd in test.runnable_llc_commands):
-                            gisel_seeds_dir.joinpath(test.path.name).symlink_to(test.path.absolute())
+                            gisel_seeds_dir.joinpath(test.path.name).symlink_to(
+                                test.path.absolute()
+                            )
+                            test.dump_bc(gisel_seeds_dir)
                 except FileExistsError as err:
                     print(err)
 
@@ -246,7 +102,7 @@ def main() -> None:
     if seeds_out:
         seeds_out.mkdir(exist_ok=True)
 
-    tests = parse_all_llc_tests(Path(args.input))
+    tests = parse_llc_tests(Path(args.input))
 
     for key, group in groupby(tests, key=lambda test: test.arch):
         arch_summary_out = summary_out.joinpath(key) if summary_out else None

--- a/scripts/classify_llc_tests.py
+++ b/scripts/classify_llc_tests.py
@@ -11,21 +11,18 @@ class Args(Tap):
     input: str = "llvm-project"
     """root of llvm-project repository"""
 
-    summary_out: Optional[str] = None
+    output: str
     """directory for storing summary (will create if not exist)"""
-
-    seeds_out: Optional[str] = None
-    """directory for storing seeds (will create if not exist)"""
 
     def configure(self):
         self.add_argument("-i", "--input")
+        self.add_argument("-o", "--output")
 
 
 def classify(
     arch: str,
     tests: List[LLCTest],
-    summary_out: Optional[Path] = None,
-    seeds_out: Optional[Path] = None,
+    summary_out: Path,
 ) -> None:
     commands = (cmd for test in tests for cmd in test.runnable_llc_commands)
 
@@ -43,78 +40,38 @@ def classify(
         ),
     )
 
-    if summary_out:
-        df.to_csv(summary_out.joinpath(f"{arch}-raw.csv"))
+    df.to_csv(summary_out.joinpath(f"{arch}-raw.csv"))
 
-        df.groupby(
-            ["arch", "gisel", "triple", "cpu", "attrs"], dropna=False
-        ).size().to_csv(summary_out.joinpath(f"{arch}-summary.csv"))
+    df.groupby(
+        ["arch", "gisel", "triple", "cpu", "attrs"], dropna=False
+    ).size().to_csv(summary_out.joinpath(f"{arch}-summary.csv"))
 
     for subarch in df["arch"].unique():
-        if summary_out:
-            subarch_df = df[df["arch"] == subarch]
+        subarch_df = df[df["arch"] == subarch]
 
-            pd.crosstab(
-                index=subarch_df["cpu"].fillna(""),
-                columns=subarch_df["attrs"],
-                dropna=False,
-            ).to_csv(summary_out.joinpath(f"{subarch}-crosstab.csv"))
-
-        if seeds_out:
-            subarch_seeds_dir = seeds_out.joinpath(subarch)
-            subarch_seeds_dir.mkdir(exist_ok=True)
-            dagisel_seeds_dir = subarch_seeds_dir.joinpath("dagisel")
-            dagisel_seeds_dir.mkdir(exist_ok=True)
-            gisel_seeds_dir = subarch_seeds_dir.joinpath("gisel")
-            gisel_seeds_dir.mkdir(exist_ok=True)
-
-            for test in tests:
-                try:
-                    if any(
-                        cmd.arch_with_sub == subarch
-                        for cmd in test.runnable_llc_commands
-                    ):
-                        if any(
-                            not cmd.global_isel for cmd in test.runnable_llc_commands
-                        ):
-                            dagisel_seeds_dir.joinpath(test.path.name).symlink_to(
-                                test.path.absolute()
-                            )
-                            test.dump_bc(dagisel_seeds_dir)
-                        if any(cmd.global_isel for cmd in test.runnable_llc_commands):
-                            gisel_seeds_dir.joinpath(test.path.name).symlink_to(
-                                test.path.absolute()
-                            )
-                            test.dump_bc(gisel_seeds_dir)
-                except FileExistsError as err:
-                    print(err)
+        pd.crosstab(
+            index=subarch_df["cpu"].fillna(""),
+            columns=subarch_df["attrs"],
+            dropna=False,
+        ).to_csv(summary_out.joinpath(f"{subarch}-crosstab.csv"))
 
 
 def main() -> None:
     args = Args(underscores_to_dashes=True).parse_args()
 
-    summary_out = Path(args.summary_out) if args.summary_out else None
-    seeds_out = Path(args.seeds_out) if args.seeds_out else None
-
-    if summary_out:
-        summary_out.mkdir(exist_ok=True)
-
-    if seeds_out:
-        seeds_out.mkdir(exist_ok=True)
+    summary_out = Path(args.output)
+    summary_out.mkdir(exist_ok=True)
 
     tests = parse_llc_tests(Path(args.input))
 
     for key, group in groupby(tests, key=lambda test: test.arch):
-        arch_summary_out = summary_out.joinpath(key) if summary_out else None
-
-        if arch_summary_out:
-            arch_summary_out.mkdir(exist_ok=True)
+        arch_summary_out = summary_out.joinpath(key)
+        arch_summary_out.mkdir(exist_ok=True)
 
         classify(
             arch=key,
             tests=list(group),
             summary_out=arch_summary_out,
-            seeds_out=seeds_out,
         )
 
 

--- a/scripts/collect_seeds.py
+++ b/scripts/collect_seeds.py
@@ -29,7 +29,7 @@ def collect_seeds_from_tests(
     global_isel: bool = False,
     dump_bc: bool = True,
     symlink_to_ll: bool = False,
-) -> None:
+) -> Path:
     if arch_with_sub is None:
         assert triple is not None, f"either arch or triple has to be specified"
         arch_with_sub = triple.split("-")[0]
@@ -57,6 +57,8 @@ def collect_seeds_from_tests(
 
             if dump_bc:
                 test.dump_bc(out_dir)
+    
+    return out_dir
 
 
 def get_seeds_dir_name_parts(

--- a/scripts/collect_seeds.py
+++ b/scripts/collect_seeds.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+from typing import Iterable, List, Optional, Set
+
+from tap import Tap
+
+from llc_test_parsing import parse_llc_tests
+
+
+class Args(Tap):
+    arch: Optional[str] = None
+    triple: Optional[str] = None
+    cpu: Optional[str] = None
+    attrs: List[str] = []
+
+    output: str
+    """directory for storing seeds (will create if not exist)"""
+
+
+def collect_seeds_from_tests(
+    out_dir_parent: Path,
+    arch_with_sub: Optional[str],
+    triple: Optional[str] = None,
+    cpu: Optional[str] = None,
+    attrs: Set[str] = set(),
+    dump_bc: bool = True,
+    symlink_to_ll: bool = False,
+) -> None:
+    if arch_with_sub is None:
+        assert triple is not None, f"either arch or triple has to be specified"
+        arch_with_sub = triple.split("-")[0]
+
+    llc_tests = parse_llc_tests(
+        arch_filter=lambda arch: arch_with_sub.startswith(arch.lower())
+    )
+
+    out_dir_parent.mkdir(exist_ok=True)
+    out_dir_name = ",".join(get_seeds_dir_name_parts(arch_with_sub, triple, cpu, attrs))
+    out_dir = out_dir_parent.joinpath(out_dir_name)
+    out_dir.mkdir()
+
+    for test in llc_tests:
+        if any(
+            cmd.arch_with_sub == arch_with_sub
+            and cmd.triple == triple
+            and cmd.cpu == cpu
+            and cmd.attrs == attrs
+            for cmd in test.runnable_llc_commands
+        ):
+            if symlink_to_ll:
+                out_dir.joinpath(test.path.name).symlink_to(test.path.absolute())
+
+            if dump_bc:
+                test.dump_bc(out_dir)
+
+
+def get_seeds_dir_name_parts(
+    arch_with_sub: str,
+    triple: Optional[str] = None,
+    cpu: Optional[str] = None,
+    attrs: Set[str] = set(),
+) -> Iterable[str]:
+    if triple:
+        yield f"triple={triple}"
+    else:
+        yield f"arch={arch_with_sub}"
+
+    if cpu:
+        yield f"cpu={cpu}"
+
+    if len(attrs) > 0:
+        yield f"attrs={','.join(attrs)}"
+
+
+def main() -> None:
+    args = Args().parse_args()
+
+    collect_seeds_from_tests(
+        out_dir_parent=Path(args.output),
+        arch_with_sub=args.arch,
+        triple=args.triple,
+        cpu=args.cpu,
+        attrs=set(args.attrs),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/collect_seeds.py
+++ b/scripts/collect_seeds.py
@@ -4,6 +4,7 @@ from typing import Iterable, List, Optional, Set
 from tap import Tap
 
 from llc_test_parsing import parse_llc_tests
+from common import TRIPLE_ARCH_MAP
 
 
 class Args(Tap):
@@ -35,7 +36,7 @@ def collect_seeds_from_tests(
         arch_with_sub = triple.split("-")[0]
 
     llc_tests = parse_llc_tests(
-        arch_filter=lambda arch: arch_with_sub.startswith(arch.lower())
+        arch_filter=lambda arch: arch == TRIPLE_ARCH_MAP[arch_with_sub]
     )
 
     out_dir_parent.mkdir(exist_ok=True)
@@ -57,7 +58,7 @@ def collect_seeds_from_tests(
 
             if dump_bc:
                 test.dump_bc(out_dir)
-    
+
     return out_dir
 
 

--- a/scripts/collect_seeds.py
+++ b/scripts/collect_seeds.py
@@ -11,9 +11,13 @@ class Args(Tap):
     triple: Optional[str] = None
     cpu: Optional[str] = None
     attrs: List[str] = []
+    global_isel: bool = False
 
     output: str
     """directory for storing seeds (will create if not exist)"""
+
+    def configure(self):
+        self.add_argument("-o", "--output")
 
 
 def collect_seeds_from_tests(
@@ -22,6 +26,7 @@ def collect_seeds_from_tests(
     triple: Optional[str] = None,
     cpu: Optional[str] = None,
     attrs: Set[str] = set(),
+    global_isel: bool = False,
     dump_bc: bool = True,
     symlink_to_ll: bool = False,
 ) -> None:
@@ -44,6 +49,7 @@ def collect_seeds_from_tests(
             and cmd.triple == triple
             and cmd.cpu == cpu
             and cmd.attrs == attrs
+            and cmd.global_isel == global_isel
             for cmd in test.runnable_llc_commands
         ):
             if symlink_to_ll:
@@ -80,6 +86,7 @@ def main() -> None:
         triple=args.triple,
         cpu=args.cpu,
         attrs=set(args.attrs),
+        global_isel=args.global_isel,
     )
 
 

--- a/scripts/fuzz.py
+++ b/scripts/fuzz.py
@@ -314,8 +314,8 @@ def batch_fuzz(
             fuzzing_command = f'screen -S {experiment.name} -dm bash -c "{fuzzing_command}" && sleep {experiment.time + 30}'
 
         process = subprocess.Popen(
-            experiment.get_fuzzing_command(out_dir),
-            env={**os.environ, **experiment.get_fuzzing_env()},
+            fuzzing_command,
+            env={**os.environ, **env},
             shell=True,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,

--- a/scripts/fuzz.py
+++ b/scripts/fuzz.py
@@ -283,8 +283,8 @@ def batch_fuzz_using_docker(
             cpuset_cpus=str(i % jobs),  # core binding
             tmpfs={"/fuzzing": "size=1G"},
             volumes=[
-                f"{seed_dir}:{seed_dir}",
-                f"{out_dir}:/output",
+                f"{seed_dir.absolute()}:{seed_dir.absolute()}",
+                f"{out_dir.absolute()}:/output",
             ],
         )
 
@@ -356,7 +356,7 @@ def fuzz(expr_config: ExperimentConfig, out_root: Path) -> int:
 def main() -> None:
     args = Args(underscores_to_dashes=True).parse_args()
 
-    out_root = Path(args.output).absolute()
+    out_root = Path(args.output)
     if out_root.exists():
         logging.info(f"{args.output} already exists.")
         if args.on_exist == "force":
@@ -370,7 +370,7 @@ def main() -> None:
         get_experiment_configs(
             fuzzer=args.fuzzer,
             cpu_attr_arch_list=args.get_cpu_attr_arch_list(),
-            seed_dir=Path(args.seeds).absolute(),
+            seed_dir=Path(args.seeds),
             seeding_from_tests=args.seeding_from_tests,
             isel=args.isel,
             time=args.get_time_in_seconds(),

--- a/scripts/fuzz.py
+++ b/scripts/fuzz.py
@@ -113,8 +113,8 @@ class Args(Tap):
 
     seeds: str
     """
-    the directory containing input seeds for fuzzing (if 'seeding_from_tests' flag is not set)
-    or the directory to store the seeds collected from tests (if 'seeding_from_tests' flag is set)
+    the directory containing input seeds for fuzzing (if 'seeding-from-tests' flag is not set)
+    or the directory to store the seeds collected from tests (if 'seeding-from-tests' flag is set)
     """
 
     seeding_from_tests: bool = False

--- a/scripts/fuzz.py
+++ b/scripts/fuzz.py
@@ -339,12 +339,12 @@ def batch_fuzz(
     common.parallel_subprocess(experiment_configs, jobs, start_subprocess, None)
 
 
-def fuzz(expr_config: ExperimentConfig, out_dir: Path) -> int:
-    expr_out_dir = expr_config.get_output_dir(out_dir)
-    os.makedirs(expr_out_dir)
+def fuzz(expr_config: ExperimentConfig, out_root: Path) -> int:
+    out_dir = expr_config.get_output_dir(out_root)
+    os.makedirs(out_dir)
 
     process = subprocess.run(
-        expr_config.get_fuzzing_command(expr_out_dir),
+        expr_config.get_fuzzing_command(out_dir),
         env={**os.environ, **expr_config.get_fuzzing_env()},
         shell=True,
     )
@@ -380,7 +380,7 @@ def main() -> None:
     )
 
     if len(expr_configs) == 1 and args.type is None:
-        exit(fuzz(expr_config=expr_configs[0], out_dir=out_root))
+        exit(fuzz(expr_config=expr_configs[0], out_root=out_root))
     elif args.type is None:
         logging.error("'--type' must be specified when running multiple fuzzing experiments")
     else:

--- a/scripts/fuzz.py
+++ b/scripts/fuzz.py
@@ -198,7 +198,7 @@ def get_experiment_configs(
                 arch_with_sub=triple.split("-")[0],
                 triple=triple,
                 cpu=None if cpu == "" else cpu,
-                attrs=set(attr.split(",")),
+                attrs=set() if attr == "" else set(attr.split(",")),
             )
 
         for r in range(repeat):
@@ -260,7 +260,7 @@ def batch_fuzz_using_docker(
 
         seed_dir = experiment.seed_dir
         out_dir = experiment.get_output_dir(out_root)
-        out_dir.mkdir()
+        out_dir.mkdir(parents=True)
 
         container = client.containers.run(
             image=DOCKER_IMAGE,
@@ -309,7 +309,7 @@ def batch_fuzz(
         logging.info(f"Starting experiment {experiment.name}...")
 
         out_dir = experiment.get_output_dir(out_root)
-        out_dir.mkdir()
+        out_dir.mkdir(parents=True)
 
         env = experiment.get_fuzzing_env()
 
@@ -341,7 +341,7 @@ def batch_fuzz(
 
 def fuzz(expr_config: ExperimentConfig, out_root: Path) -> int:
     out_dir = expr_config.get_output_dir(out_root)
-    out_dir.mkdir()
+    out_dir.mkdir(parents=True)
 
     process = subprocess.run(
         expr_config.get_fuzzing_command(out_dir),

--- a/scripts/llc_test_parsing.py
+++ b/scripts/llc_test_parsing.py
@@ -1,0 +1,184 @@
+from pathlib import Path
+import re
+import subprocess
+from typing import Callable, Iterable, List, Optional, Set
+
+
+class LLCCommand:
+    arch_with_sub: str
+    cpu: Optional[str]
+    triple: Optional[str]
+    attrs: Set[str]
+    global_isel: bool
+
+    def __init__(self, command: str, default_triple: Optional[str] = None) -> None:
+        assert "llc" in command
+
+        if (match := re.match(r".*-mtriple[= ]\"?([a-z0-9_-]+)", command)) is not None:
+            self.triple = match.group(1)
+        else:
+            self.triple = default_triple
+
+        if (match := re.match(r".*-march[= ]\"?([a-z0-9_-]+)", command)) is not None:
+            self.arch_with_sub = match.group(1)
+        elif self.triple is not None:
+            self.arch_with_sub = self.triple.split("-")[0]
+        else:
+            raise Exception(f"Failed to determine arch")
+
+        assert self.triple is not None or self.arch_with_sub is not None, f"FATAL"
+
+        if (match := re.match(r".*-mcpu[= ]\"?([a-z0-9-]+)", command)) is not None:
+            self.cpu = match.group(1)
+        else:
+            self.cpu = None
+
+        self.attrs = set(
+            ("+" + attr) if not attr.startswith(("+", "-")) else attr
+            for arg_val in re.findall(r"-mattr[= ]\"?([A-Za-z0-9,\+-]+)", command)
+            for attr in arg_val.split(",")
+        )
+
+        assert all(
+            attr.startswith(("+", "-")) for attr in self.attrs
+        ), f"Invalid attribute"
+
+        self.global_isel = re.match(r".*-global-isel", command) is not None
+
+
+class LLCTest:
+    path: Path
+
+    arch: str
+
+    test_commands: List[str]
+
+    runnable_llc_commands: List[LLCCommand]
+    """
+    llc commands that can be directly executed without crashing using the test case as an input
+    without going through `opt`, `sed`, etc. first.
+    """
+
+    code_lines: List[str]
+
+    def __init__(self, arch: str, file_path: Path) -> None:
+        assert file_path.name.endswith(".ll")
+
+        self.arch = arch
+        self.path = file_path
+        self.test_commands = []
+        self.code_lines = []
+
+        with open(file_path) as file:
+            multiline_command = False  # whether last RUN header ends with '\'
+            while line := file.readline():
+                if re.match(r".*;.+NOTE:(.+)", line):
+                    continue
+
+                match = re.match(r".*;.*RUN:(.+)", line)
+
+                if match is not None:
+                    command = match.group(1).strip()
+
+                    if multiline_command:
+                        last_command_prev_part = (
+                            self.test_commands[-1].removesuffix("\\").strip()
+                        )
+                        self.test_commands[-1] = f"{last_command_prev_part} {command}"
+                    else:
+                        self.test_commands.append(command)
+
+                    multiline_command = command.endswith("\\")
+                else:
+                    assert (
+                        not multiline_command
+                    ), f"ERROR: something unexpected happened when parsing commands for {file_path}"
+                    self.code_lines.append(line)
+
+        assert (
+            len(self.test_commands) > 0
+        ), f"WARNING: {file_path} does not contain any test command."
+
+        assert (
+            len(self.code_lines) > 0
+        ), f"WARNING: {file_path} does not contain any test code."
+
+        llc_commands = [cmd for cmd in self.test_commands if "llc " in cmd]
+        assert (
+            len(llc_commands) > 0
+        ), f"WARNING: {file_path} does not contain any `llc` command."
+
+        default_triple = self.get_default_triple()
+        runnable_llc_commands_raw = filter(
+            lambda cmd: cmd.startswith("llc"),
+            (cmd.split("|")[0] for cmd in llc_commands),
+        )
+
+        try:
+            self.runnable_llc_commands = [
+                LLCCommand(cmd, default_triple) for cmd in runnable_llc_commands_raw
+            ]
+        except Exception as e:
+            raise Exception(
+                f"ERROR: Failed to parse llc command(s) in {file_path}."
+            ) from e
+
+        assert (
+            len(self.runnable_llc_commands) > 0
+        ), f"WARNING: {file_path} does not contain any runnable `llc` command."
+
+    def get_default_triple(self) -> Optional[str]:
+        lines_with_triple = [
+            line for line in self.code_lines if line.startswith("target triple")
+        ]
+
+        if len(lines_with_triple) == 0:
+            return None
+
+        assert (
+            len(lines_with_triple) == 1
+        ), f"UNEXPECTED: {self.path} has more than one triple specified in code"
+
+        match = re.match(r'target triple ?= ?"([a-z0-9_\.-]+)"', lines_with_triple[0])
+        assert (
+            match is not None
+        ), f"UNEXPECTED: failed to extract triple from '{lines_with_triple[0]}'"
+
+        return match.group(1)
+
+    def dump_bc(self, out_dir: Path) -> None:
+        out_path = out_dir.joinpath(self.path.name.removesuffix(".ll") + ".bc")
+
+        process = subprocess.run(
+            [
+                "./llvm-project/build-release/bin/llvm-as",
+                self.path,
+                "-o",
+                out_path,
+            ]
+        )
+
+        if process.returncode != 0:
+            print(f"WARNING: failed to convert {self.path} to {out_path}")
+
+
+def parse_llc_tests(
+    llvm_root: Path = Path("llvm-project"),
+    arch_filter: Callable[[str], bool] = lambda _: True,
+) -> Iterable[LLCTest]:
+    total = 0
+    success = 0
+
+    for arch_dir in llvm_root.joinpath("llvm/test/CodeGen").iterdir():
+        if not arch_dir.is_dir() or not arch_filter(arch_dir.name):
+            continue
+
+        for file_path in arch_dir.rglob("*.ll"):
+            try:
+                yield LLCTest(arch_dir.name, file_path)
+                success += 1
+            except Exception as e:
+                print(e)
+            total += 1
+
+    print(f"Successfully parsed {success}/{total} LLC tests.")


### PR DESCRIPTION
- [x] Fix LLC test command attribute parsing 
- [x] Extract LLC test parsing classes and function into `llc_test_parsing.py`
- [x] Add script `collect_seeds.py` to collect LLC tests that matches the specified _arch/triple, cpu, attr_ combo and compile them into bitcode files
- [x] Updated `fuzz.py` to support seeding from tests with `--seeding-from-tests` option
- [x] Updated `fuzz.py` to display AFL UI when running just one experiment (no need to collect seeds, set environment variables,  and type long AFL command manually anymore)