### PR TITLE
Siyuan/requirement txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,12 @@ To install some dependencies you may want to:
 # `apt install -y python3.8 python3-pip wget`
 wget https://bootstrap.pypa.io/get-pip.py
 python3.8 get-pip.py
-pip3.8 install -r ./scripts/requirements.txt
+# tqdm is a must to track the process of a task
+pip3.8 install tqdm 
+# It's ok to not install these if you don't intend to do data analysis
+pip3.8 install panda matplotlib
+# You can install all the dependencies of the scripts with:
+pip3.8 install -r scripts/requirements.txt
 ```
 
 ### Description and usage

--- a/README.md
+++ b/README.md
@@ -118,10 +118,7 @@ To install some dependencies you may want to:
 # `apt install -y python3.8 python3-pip wget`
 wget https://bootstrap.pypa.io/get-pip.py
 python3.8 get-pip.py
-# tqdm is a must to track the process of a task
-pip3.8 install tqdm 
-# It's ok to not install these if you don't intend to do data analysis
-pip3.8 install panda matplotlib
+pip3.8 install -r requirements.txt
 ```
 
 ### Description and usage

--- a/README.md
+++ b/README.md
@@ -110,20 +110,17 @@ Check `./script/common.py`.
 ### Dependencies
 
 We prepared many scripts to automate the fuzzing process.
-These scripts runs on Python 3.8+, as it supports type hints to make it look less messy.
-Use `python3.8` explictly to avoid conflict with `python3.6`... suppose you are still using ubuntu 18.04 or order.
+These scripts runs on Python 3.10+, as it supports type hints to make it look less messy.
+Use `python3.10` explictly to avoid conflict with `python3.6`... suppose you are still using ubuntu 18.04 or order.
 To install some dependencies you may want to:
 ```sh
-# If your ubuntu is so old you don't have python3.8 in your apt I can't help you...
-# `apt install -y python3.8 python3-pip wget`
+# If your ubuntu is so old you don't have python3.10 in your apt I can't help you...
+# `apt install -y python3.10 python3-pip wget`
 wget https://bootstrap.pypa.io/get-pip.py
-python3.8 get-pip.py
-# tqdm is a must to track the process of a task
-pip3.8 install tqdm 
-# It's ok to not install these if you don't intend to do data analysis
-pip3.8 install panda matplotlib
+python3.10 get-pip.py
+
 # You can install all the dependencies of the scripts with:
-pip3.8 install -r scripts/requirements.txt
+pip3.10 install -r scripts/requirements.txt
 ```
 
 ### Description and usage
@@ -138,7 +135,7 @@ Using `fuzz.py` don't need you to set any environment variables, the script will
 You would most likely use the `fuzz.py` like this:
 
 ```sh
-python3.8 scripts/fuzz.py -i seeds -o fuzzing -r 5 --set="  aie" --type=screen --isel=dagisel --fuzzer=irfuzzer --time=1w -j 80 --on_exist=force
+python3.10 scripts/fuzz.py -i seeds -o fuzzing -r 5 --set="  aie" --type=screen --isel=dagisel --fuzzer=irfuzzer --time=1w -j 80 --on_exist=force
 ```
 
 It means: start fuzzing using input from `seeds` (`-i seed`), put the result in `fuzzing` (`-o fuzzing`), repeat the experiment for five times (`-r 5`), test aie without attribute and cpu setting (`--set="  aie"`), use screen to monitor the fuzzing (`--type=screen`), test SelectionDAG (`--isel=dagisel`), use our fuzzer (`--fuzzer=irfuzzer`), test for a week (`--time=1w`), start at most 80 jobs in parallel (`-j 80`) and if the output directory already exists, force remove it (`--on_exist=force`)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ To install some dependencies you may want to:
 # `apt install -y python3.8 python3-pip wget`
 wget https://bootstrap.pypa.io/get-pip.py
 python3.8 get-pip.py
-pip3.8 install -r requirements.txt
+pip3.8 install -r ./scripts/requirements.txt
 ```
 
 ### Description and usage

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,5 +1,3 @@
-# Generated with pipreqs
-# https://stackoverflow.com/questions/31684375/automatically-create-requirements-txt
 bitarray==2.8.0
 docker_py==1.10.6
 matplotlib==3.5.1

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,9 @@
+# Generated with pipreqs
+# https://stackoverflow.com/questions/31684375/automatically-create-requirements-txt
+bitarray==2.8.0
+docker_py==1.10.6
+matplotlib==3.5.1
+numpy==1.21.5
+pandas==2.0.3
+tqdm==4.65.0
+typed_argument_parser==1.8.1


### PR DESCRIPTION
Add requirements.txt into _scripts_ directory.

I collected dependencies with **pipreqs** module (https://pypi.org/project/pipreqs/) and verifies all dependencies are installed with command `pip3.8 install -r scripts/requirements.txt` with a clone of IRFuzzer project on a fresh linux machine.